### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,16 +28,16 @@ To run the example project, clone the repo, and run `pod install` from the Examp
 
 ## Installation
 
-### Installation with Cocoapods
+### Installation with CocoaPods
 
-ALAccordion is written in Swift, so to install with Cocoapods, you must target `iOS 8` or later.
+ALAccordion is written in Swift, so to install with CocoaPods, you must target `iOS 8` or later.
 
-Install Cocoapods 0.36.0 or newer
+Install CocoaPods 0.36.0 or newer
 ```shell
 [sudo] gem install cocoapods
 ```
 
-Add ALAccordion to your Podfile. **Note**: You must add the `use_frameworks!` line to use Swift in Cocoapods:
+Add ALAccordion to your Podfile. **Note**: You must add the `use_frameworks!` line to use Swift in CocoaPods:
 ```ruby
 # Podfile
 target 'My Target' do


### PR DESCRIPTION

This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>
<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
